### PR TITLE
feat: expose GLANCE_KUBE_API_QPS / GLANCE_KUBE_API_BURST env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,17 @@ metadata:
 ```
 
 
+## Configuration
+
+The extension is configured through environment variables:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `GLANCE_DEBUG` | _unset_ | When set to any non-empty value, enables debug-level logging. |
+| `GLANCE_KUBE_CONFIG` | `$HOME/.kube/config` | Path to a kubeconfig file. Ignored when running in-cluster. |
+| `GLANCE_KUBE_API_QPS` | client-go default (5) | Raises the client-go QPS limit when talking to the kube-apiserver. Useful when a dashboard with many widgets fans out enough parallel list calls to exhaust the default rate limit (`client-side throttling, not priority and fairness` warnings in the logs). |
+| `GLANCE_KUBE_API_BURST` | client-go default (10) | Raises the client-go burst limit. Should generally be set together with `GLANCE_KUBE_API_QPS`. |
+
 ## Installation
 
 Glance itself provides a container image, but no official helm chart yet.

--- a/internal/k8s/api/client.go
+++ b/internal/k8s/api/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strconv"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -24,6 +25,8 @@ func Connect() (*Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not read kubernetes config: %w", err)
 	}
+
+	applyRateLimitOverrides(config)
 
 	kube, err := kubernetes.NewForConfig(config)
 	if err != nil {
@@ -70,6 +73,30 @@ func findKubernetesConfigFilename() string {
 	}
 
 	return os.ExpandEnv("${HOME}/.kube/config")
+}
+
+// applyRateLimitOverrides lets operators raise client-go's default
+// rate limit (5 QPS / 10 burst) when a dashboard fans out enough
+// parallel widget calls to exhaust it. Leaves the defaults in place
+// when the env vars are unset or malformed.
+func applyRateLimitOverrides(config *rest.Config) {
+	if v := os.Getenv("GLANCE_KUBE_API_QPS"); v != "" {
+		if qps, err := strconv.ParseFloat(v, 32); err == nil && qps > 0 {
+			config.QPS = float32(qps)
+			slog.Debug("overriding kube api qps", slog.Float64("qps", qps))
+		} else {
+			slog.Warn("ignoring invalid GLANCE_KUBE_API_QPS", slog.String("value", v))
+		}
+	}
+
+	if v := os.Getenv("GLANCE_KUBE_API_BURST"); v != "" {
+		if burst, err := strconv.Atoi(v); err == nil && burst > 0 {
+			config.Burst = burst
+			slog.Debug("overriding kube api burst", slog.Int("burst", burst))
+		} else {
+			slog.Warn("ignoring invalid GLANCE_KUBE_API_BURST", slog.String("value", v))
+		}
+	}
 }
 
 type fetchFunc[Item any] func(context.Context, listOptions) ([]Item, string, error)

--- a/internal/k8s/api/client_test.go
+++ b/internal/k8s/api/client_test.go
@@ -1,0 +1,70 @@
+package api
+
+import (
+	"testing"
+
+	"k8s.io/client-go/rest"
+)
+
+func TestApplyRateLimitOverrides(t *testing.T) {
+	tests := []struct {
+		name      string
+		qpsEnv    string
+		burstEnv  string
+		wantQPS   float32
+		wantBurst int
+	}{
+		{
+			name:      "defaults preserved when env unset",
+			qpsEnv:    "",
+			burstEnv:  "",
+			wantQPS:   0,
+			wantBurst: 0,
+		},
+		{
+			name:      "valid values applied",
+			qpsEnv:    "50",
+			burstEnv:  "100",
+			wantQPS:   50,
+			wantBurst: 100,
+		},
+		{
+			name:      "fractional qps applied",
+			qpsEnv:    "12.5",
+			burstEnv:  "25",
+			wantQPS:   12.5,
+			wantBurst: 25,
+		},
+		{
+			name:      "invalid qps ignored, burst applied",
+			qpsEnv:    "notanumber",
+			burstEnv:  "20",
+			wantQPS:   0,
+			wantBurst: 20,
+		},
+		{
+			name:      "non-positive values ignored",
+			qpsEnv:    "0",
+			burstEnv:  "-1",
+			wantQPS:   0,
+			wantBurst: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("GLANCE_KUBE_API_QPS", tc.qpsEnv)
+			t.Setenv("GLANCE_KUBE_API_BURST", tc.burstEnv)
+
+			cfg := &rest.Config{}
+			applyRateLimitOverrides(cfg)
+
+			if cfg.QPS != tc.wantQPS {
+				t.Errorf("QPS: got %v, want %v", cfg.QPS, tc.wantQPS)
+			}
+			if cfg.Burst != tc.wantBurst {
+				t.Errorf("Burst: got %d, want %d", cfg.Burst, tc.wantBurst)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Expose client-go's `rest.Config.QPS` / `rest.Config.Burst` via two new
env vars so operators can raise the default 5 QPS / 10 burst rate
limit without forking. Defaults are unchanged.

## Motivation

`/extension/apps` fires fresh cluster-wide `List()` calls on every
request (no in-process informer cache). On a Glance dashboard with
multiple per-category widgets — one widget per `glance/id` value,
each with a distinct `show-if` filter — the calls fan out in parallel
and exhaust client-go's default rate limit.

Reproduction (my cluster, v0.4.9, 15 per-category widgets, ~50 apps):

- Cold load of `/api/pages/startpage/content/` consistently ~7s
- k8s-extension logs show `client-side throttling, not priority and fairness` on `apps/v1/statefulsets`, delays >1s

Each widget call fans out to ~6 lists (deployments, statefulsets,
daemonsets, services, ingresses, httproutes), so 15 widgets ≈ 90 list
calls hitting the QPS limiter.

With `GLANCE_KUBE_API_QPS=50` + `GLANCE_KUBE_API_BURST=100` the cold
load drops well under a second.

## What changed

- `internal/k8s/api/client.go`: new `applyRateLimitOverrides()`
  applied after `readKubernetesConfig()`. Unset / invalid /
  non-positive values fall back to client-go defaults with a
  `slog.Warn`.
- `internal/k8s/api/client_test.go`: table-driven coverage for parse
  + validation paths.
- `README.md`: new `## Configuration` section documenting all four
  env vars (existing `GLANCE_DEBUG` / `GLANCE_KUBE_CONFIG` were
  undocumented).

## Notes for reviewers

This is a tactical workaround — the structurally-correct fix is
switching to `SharedInformerFactory` so the per-request `List()` cost
disappears entirely. Happy to take a swing at that as a follow-up if
the direction sounds good; flag-tuning unblocks operators today
without changing architecture.

## Test plan

- [x] go build ./...
- [x] go vet ./...
- [x] go test ./internal/k8s/api/... -v (5/5 pass)
- [x] Verified defaults preserved when env unset
- [x] Verified invalid values logged and ignored